### PR TITLE
Add localities, attributes, and locations to clusters

### DIFF
--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -118,7 +118,7 @@ chown -R ubuntu:ubuntu /home/ubuntu/.kube
 ####################
 
 LOCALITY="region={{Region}},availability-zone={{AvailabilityZone}}"
-ATTRS="InstanceType={{InstanceType}}"
+ATTRS="instance-type={{InstanceType}}"
 
 # update default config to use desired settings
 /tmp/update-crdb-statefulset.py \

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -29,6 +29,7 @@ test -n "{{NetworkingProviderUrl}}"
 test -n "{{DashboardUrl}}"
 test -n "{{StorageClassUrl}}"
 test -n "{{Region}}"
+test -n "{{AvailabilityZone}}"
 test -n "{{CockroachNodeCount}}"
 test -n "{{CockroachVolumeSize}}"
 test -n "{{CockroachDockerVersionTag}}"
@@ -113,10 +114,12 @@ chown -R ubuntu:ubuntu /home/ubuntu/.kube
 #Install CockroachDB
 ####################
 
+LOCALITY="Region={{Region}},AvailabilityZone={{AvailabilityZone}}"
+
 # update default config to use desired settings
 /tmp/update-crdb-statefulset.py \
     https://cockroach-cloudformation.s3.amazonaws.com/kubernetes/scripts/cockroachdb-statefulset.yaml \
-    --size {{CockroachVolumeSize}} --version-tag {{CockroachDockerVersionTag}} > /tmp/cockroachdb-statefulset.yaml
+    --size {{CockroachVolumeSize}} --version-tag {{CockroachDockerVersionTag}} --locality=$LOCALITY > /tmp/cockroachdb-statefulset.yaml
 
 kubectl apply -f /tmp/cockroachdb-statefulset.yaml
 kubectl scale statefulset cockroachdb --replicas={{CockroachNodeCount}}

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -35,6 +35,8 @@ test -n "{{CockroachNodeCount}}"
 test -n "{{CockroachVolumeSize}}"
 test -n "{{CockroachDockerVersionTag}}"
 test -n "{{NodePortConfigUrl}}"
+test -n "{{RegionLatitude}}"
+test -n "{{RegionLongitude}}"
 
 # kubeadm wants lowercase for DNS (as it probably should)
 LB_DNS=$(echo "{{LoadBalancerDns}}" | tr 'A-Z' 'a-z')
@@ -115,18 +117,28 @@ chown -R ubuntu:ubuntu /home/ubuntu/.kube
 #Install CockroachDB
 ####################
 
-LOCALITY="Region={{Region}},AvailabilityZone={{AvailabilityZone}}"
+LOCALITY="region={{Region}},availability-zone={{AvailabilityZone}}"
 ATTRS="InstanceType={{InstanceType}}"
 
 # update default config to use desired settings
 /tmp/update-crdb-statefulset.py \
     https://cockroach-cloudformation.s3.amazonaws.com/kubernetes/scripts/cockroachdb-statefulset.yaml \
-    --size {{CockroachVolumeSize}} --version-tag {{CockroachDockerVersionTag}} --locality=$LOCALITY \
-     --attrs=$ATTRS > /tmp/cockroachdb-statefulset.yaml
+    --size {{CockroachVolumeSize}} --version-tag {{CockroachDockerVersionTag}} --locality $LOCALITY \
+    --attrs=$ATTRS > /tmp/cockroachdb-statefulset.yaml
 
 kubectl apply -f /tmp/cockroachdb-statefulset.yaml
 kubectl scale statefulset cockroachdb --replicas={{CockroachNodeCount}}
 kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cluster-init.yaml
 kubectl create -f {{NodePortConfigUrl}}
 
-#todo: create job for adding lat/long
+#create job to associate {{Region}} with {{RegionLatitude}}, {{RegionLongitude}}"
+
+if [[ {{CockroachDockerVersionTag}} =~ :v2.0 ]]
+then
+    kubectl run set-locality-coordinates --image=cockroachdb/cockroach --restart=OnFailure -- \
+    sql --insecure --host=cockroachdb-0.cockroachdb -e  \
+    "INSERT INTO system.locations (\"localityKey\", \"localityValue\", latitude, longitude) VALUES ('region', '{{Region}}', {{RegionLatitude}}, {{RegionLongitude}})"
+fi
+
+
+

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -30,6 +30,7 @@ test -n "{{DashboardUrl}}"
 test -n "{{StorageClassUrl}}"
 test -n "{{Region}}"
 test -n "{{AvailabilityZone}}"
+test -n "{{InstanceType}}"
 test -n "{{CockroachNodeCount}}"
 test -n "{{CockroachVolumeSize}}"
 test -n "{{CockroachDockerVersionTag}}"
@@ -115,11 +116,13 @@ chown -R ubuntu:ubuntu /home/ubuntu/.kube
 ####################
 
 LOCALITY="Region={{Region}},AvailabilityZone={{AvailabilityZone}}"
+ATTRS="InstanceType={{InstanceType}}"
 
 # update default config to use desired settings
 /tmp/update-crdb-statefulset.py \
     https://cockroach-cloudformation.s3.amazonaws.com/kubernetes/scripts/cockroachdb-statefulset.yaml \
-    --size {{CockroachVolumeSize}} --version-tag {{CockroachDockerVersionTag}} --locality=$LOCALITY > /tmp/cockroachdb-statefulset.yaml
+    --size {{CockroachVolumeSize}} --version-tag {{CockroachDockerVersionTag}} --locality=$LOCALITY \
+     --attrs=$ATTRS > /tmp/cockroachdb-statefulset.yaml
 
 kubectl apply -f /tmp/cockroachdb-statefulset.yaml
 kubectl scale statefulset cockroachdb --replicas={{CockroachNodeCount}}

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -133,7 +133,7 @@ kubectl create -f {{NodePortConfigUrl}}
 
 #create job to associate {{Region}} with {{RegionLatitude}}, {{RegionLongitude}}"
 
-if [[ {{CockroachDockerVersionTag}} =~ :v2.0 ]]
+if [[ {{CockroachDockerVersionTag}} =~ :v2 ]]
 then
     kubectl run set-locality-coordinates --image=cockroachdb/cockroach --restart=OnFailure -- \
     sql --insecure --host=cockroachdb-0.cockroachdb -e  \

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -128,3 +128,5 @@ kubectl apply -f /tmp/cockroachdb-statefulset.yaml
 kubectl scale statefulset cockroachdb --replicas={{CockroachNodeCount}}
 kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cluster-init.yaml
 kubectl create -f {{NodePortConfigUrl}}
+
+#todo: create job for adding lat/long

--- a/scripts/update-crdb-statefulset.py
+++ b/scripts/update-crdb-statefulset.py
@@ -5,7 +5,8 @@ parser = argparse.ArgumentParser(description='Update statefulset yaml with user-
 parser.add_argument('config_yaml', metavar="config_file_url", help='url to yaml file containing cockroachdb statefulset configuration')
 parser.add_argument('--size',  dest="size_in_gb", type=int, help='Desired volume size in GiB')
 parser.add_argument('--version-tag', dest="version_tag", help='CockroachDB Docker tag to use')
-parser.add_argument('--locality', dest="locality", help='Locality arguments to use')
+parser.add_argument('--locality', dest="locality", required=True, help='Locality argument to use')
+parser.add_argument('--attrs', dest="attrs", required=True, help='Attribute argument to use')
 
 args = parser.parse_args()
 
@@ -18,16 +19,16 @@ for config in configs:
         if args.size_in_gb:
             config['spec']['volumeClaimTemplates'][0]['spec']['resources']['requests']['storage'] = str(args.size_in_gb) + 'Gi'
 
-        if args.locality:
-            for container in config['spec']['template']['spec']['containers']:
-                if container['name'] == 'cockroachdb':
-                    container['command'] = [
-                        "/bin/bash",
-                        "-ecx",
-                        "exec /cockroach/cockroach start --logtostderr --insecure --host $(hostname -f) --locality=" +
-                            args.locality +" --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
-                    ]
-                    break
+
+        for container in config['spec']['template']['spec']['containers']:
+            if container['name'] == 'cockroachdb':
+                container['command'] = [
+                    "/bin/bash",
+                    "-ecx",
+                    "exec /cockroach/cockroach start --logtostderr --insecure --host $(hostname -f) --locality=" +
+                        args.locality +" --http-host 0.0.0.0 --attrs=" + args.attrs + " --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
+                ]
+                break
 
 
         if args.version_tag:

--- a/scripts/update-crdb-statefulset.py
+++ b/scripts/update-crdb-statefulset.py
@@ -5,6 +5,7 @@ parser = argparse.ArgumentParser(description='Update statefulset yaml with user-
 parser.add_argument('config_yaml', metavar="config_file_url", help='url to yaml file containing cockroachdb statefulset configuration')
 parser.add_argument('--size',  dest="size_in_gb", type=int, help='Desired volume size in GiB')
 parser.add_argument('--version-tag', dest="version_tag", help='CockroachDB Docker tag to use')
+parser.add_argument('--locality', dest="locality", help='Locality arguments to use')
 
 args = parser.parse_args()
 
@@ -16,6 +17,18 @@ for config in configs:
     if config['kind'] == 'StatefulSet':
         if args.size_in_gb:
             config['spec']['volumeClaimTemplates'][0]['spec']['resources']['requests']['storage'] = str(args.size_in_gb) + 'Gi'
+
+        if args.locality:
+            for container in config['spec']['template']['spec']['containers']:
+                if container['name'] == 'cockroachdb':
+                    container['command'] = [
+                        "/bin/bash",
+                        "-ecx",
+                        "exec /cockroach/cockroach start --logtostderr --insecure --host $(hostname -f) --locality=" +
+                            args.locality +" --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
+                    ]
+                    break
+
 
         if args.version_tag:
             for container in config['spec']['template']['spec']['containers']:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -411,7 +411,7 @@ Resources:
                 StorageClassUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/default.storageclass.yaml"
                 NodePortConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-nodeport-config.yaml"
                 Region: !Ref AWS::Region
-                AvailabilityZone: !GetAtt K8sMasterInstance.AvailabilityZone
+                AvailabilityZone: !Ref AvailabilityZone
                 CockroachDockerVersionTag:
                     Fn::FindInMap:
                     - VersionTagMap

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -237,32 +237,60 @@ Mappings:
   RegionMap:
     us-west-1:
       '64': ami-965965f6
+      'lat': 37.44
+      'long': -122.14
     ap-south-1:
       '64': ami-27d59748
+      'lat': 19.08
+      'long': 72.88
     eu-west-2:
       '64': ami-22908d46
+      'lat': 39.96
+      'long': -83.00
     eu-west-1:
       '64': ami-a7df7ade
+      'lat': 53.35
+      'long': -6.26
     ap-northeast-2:
       '64': ami-4401a42a
+      'lat': 37.57
+      'long': 126.98
     ap-northeast-1:
       '64': ami-ad60c1cb
+      'lat': 35.41
+      'long': 139.42
     sa-east-1:
       '64': ami-db1860b7
+      'lat': -23.34
+      'long': -46.38
     ca-central-1:
       '64': ami-c7843ca3
+      'lat': 45.50
+      'long': -73.57
     ap-southeast-1:
       '64': ami-dce8a9bf
+      'lat': 1.37
+      'long': 103.80
     ap-southeast-2:
       '64': ami-408c6322
+      'lat': -33.86
+      'long': 151.20
     eu-central-1:
       '64': ami-3058e35f
+      'lat': 50.1167
+      'long': 8.6833
     us-east-1:
       '64': ami-9fa90ee5
+      'lat': 38.13
+      'long': -78.45
     us-east-2:
       '64': ami-4686aa23
+      'lat': 39.96
+      'long': -83.00
     us-west-2:
       '64': ami-f431fe8c
+      'lat': 46.15
+      'long': -123.88
 
   VersionTagMap:
     v1.1.4:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -411,6 +411,7 @@ Resources:
                 StorageClassUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/default.storageclass.yaml"
                 NodePortConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-nodeport-config.yaml"
                 Region: !Ref AWS::Region
+                AvailabilityZone: !GetAtt K8sMasterInstance.AvailabilityZone
                 CockroachDockerVersionTag:
                     Fn::FindInMap:
                     - VersionTagMap

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -412,6 +412,7 @@ Resources:
                 NodePortConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-nodeport-config.yaml"
                 Region: !Ref AWS::Region
                 AvailabilityZone: !Ref AvailabilityZone
+                InstanceType: !Ref InstanceType
                 CockroachDockerVersionTag:
                     Fn::FindInMap:
                     - VersionTagMap

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -245,8 +245,8 @@ Mappings:
       'long': 72.88
     eu-west-2:
       '64': ami-22908d46
-      'lat': 39.96
-      'long': -83.00
+      'lat': 51.51
+      'long': -0.13
     eu-west-1:
       '64': ami-a7df7ade
       'lat': 53.35
@@ -440,6 +440,16 @@ Resources:
                 NodePortConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-nodeport-config.yaml"
                 Region: !Ref AWS::Region
                 AvailabilityZone: !Ref AvailabilityZone
+                RegionLatitude:
+                    Fn::FindInMap:
+                    - RegionMap
+                    - !Ref AWS::Region
+                    - 'lat'
+                RegionLongitude:
+                    Fn::FindInMap:
+                    - RegionMap
+                    - !Ref AWS::Region
+                    - 'long'
                 InstanceType: !Ref InstanceType
                 CockroachDockerVersionTag:
                     Fn::FindInMap:


### PR DESCRIPTION
Automatically tag nodes with a locality and attribute signifying the aws region/az pair and ec2 instance type, respectively. 

If this is a 2.x cluster, the template will insert lat/long values for the region into the system.locations table so the cluster can be plotted on a map.