### PR TITLE
Upgrade persistent storage to use Provisioned IOPS SSD volumes

### DIFF
--- a/ci/new-vpc-inputs-multi-node-stable.json
+++ b/ci/new-vpc-inputs-multi-node-stable.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "DiskSizeGb",
-        "ParameterValue": "1"
+        "ParameterValue": "5"
     },
     {
         "ParameterKey": "K8sNodeCapacity",

--- a/ci/new-vpc-inputs-single-node-alpha.json
+++ b/ci/new-vpc-inputs-single-node-alpha.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "DiskSizeGb",
-        "ParameterValue": "1"
+        "ParameterValue": "5"
     },
     {
         "ParameterKey": "K8sNodeCapacity",

--- a/scripts/default.storageclass.yaml
+++ b/scripts/default.storageclass.yaml
@@ -1,9 +1,11 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: gp2
+  name: io1
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/aws-ebs
 parameters:
-  type: gp2
+  type: io1
+  iopsPerGB: "5"
+

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -100,10 +100,10 @@ Parameters:
   # Specifies the size of the root disk for all EC2 instances, including master
   # and nodes.
   DiskSizeGb:
-    Description: 'Size of the disk for each CockroachDB node.'
+    Description: 'Provisioned IOPS SSD volume size for each CockroachDB node.'
     Default: 20
     Type: Number
-    MinValue: 1
+    MinValue: 4
     MaxValue: 1024
 
   AdminIngressLocation:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -146,10 +146,10 @@ Parameters:
   # Specifies the size of the root disk for all EC2 instances, including master
   # and nodes.
   DiskSizeGb:
-    Description: 'Size of the disk for each CockroachDB node.'
+    Description: 'Provisioned IOPS SSD volume size for each CockroachDB node.'
     Default: 20
     Type: Number
-    MinValue: 1
+    MinValue: 4
     MaxValue: 1024
 
   # Required. This is an availability zone from your region


### PR DESCRIPTION
Upgrade from General Purpose SSDs to faster Provisioned IOPS SSDs to deliver a constant 5 iops/GB.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html