### PR TITLE
Bumped alpha version to v2.0-alpha.20180129

### DIFF
--- a/ci/new-vpc-inputs-single-node-alpha.json
+++ b/ci/new-vpc-inputs-single-node-alpha.json
@@ -17,7 +17,7 @@
     },
     {
         "ParameterKey": "Version",
-        "ParameterValue": "v2.0-alpha.20180122"
+        "ParameterValue": "v2.0-alpha.20180129"
     },
     {
         "ParameterKey": "QSS3BucketName",

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -72,7 +72,7 @@ Parameters:
     AllowedValues:
     - v1.1.4
     - v1.0.6
-    - v2.0-alpha.20180122
+    - v2.0-alpha.20180129
 
   KeyName:
     Description: Existing EC2 KeyPair for SSH access.
@@ -104,7 +104,7 @@ Parameters:
     Default: 20
     Type: Number
     MinValue: 4
-    MaxValue: 1024
+    MaxValue: 4096
 
   AdminIngressLocation:
     Description: IP address range (CIDR notation) to allow access to the CockroachDB Web UI, PostgreSQL ports,

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -121,7 +121,7 @@ Parameters:
     AllowedValues:
     - v1.1.4
     - v1.0.6
-    - v2.0-alpha.20180122
+    - v2.0-alpha.20180129
 
 
   # https://aws.amazon.com/ec2/instance-types/
@@ -150,7 +150,7 @@ Parameters:
     Default: 20
     Type: Number
     MinValue: 4
-    MaxValue: 1024
+    MaxValue: 4096
 
   # Required. This is an availability zone from your region
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
@@ -297,8 +297,8 @@ Mappings:
       'image': 'cockroachdb/cockroach:v1.1.4'
     v1.0.6:
       'image': 'cockroachdb/cockroach:v1.0.6'
-    v2.0-alpha.20180122:
-      'image': 'cockroachdb/cockroach-unstable:v2.0-alpha.20180122'
+    v2.0-alpha.20180129:
+      'image': 'cockroachdb/cockroach-unstable:v2.0-alpha.20180129'
 
 
 # Helper Conditions which help find the right values for resources


### PR DESCRIPTION
Alpha version bump. Additionally, raised SSD volume size limit to match AWS max volume size