### PR TITLE
Stop using hard coded 'latest' docker release

### DIFF
--- a/ci/config.yml
+++ b/ci/config.yml
@@ -11,14 +11,16 @@ tests:
     parameter_input: new-vpc-inputs-multi-node-stable.json
     template_file: kubernetes-cluster-with-new-vpc.template
   single-node-vpc-alpha:
+    regions:
+      - eu-west-1
     parameter_input: new-vpc-inputs-single-node-pre-release.json
     template_file: kubernetes-cluster-with-new-vpc.template
   single-node-vpc-kv:
+    regions:
+      - eu-west-1
     parameter_input: new-vpc-inputs-single-node-kv.json
     template_file: kubernetes-cluster-with-new-vpc.template
   multi-node-vpc-kv:
-    regions:
-      - eu-west-1
     parameter_input: new-vpc-inputs-multi-node-kv.json
     template_file: kubernetes-cluster-with-new-vpc.template
 

--- a/ci/new-vpc-inputs-single-node-kv.json
+++ b/ci/new-vpc-inputs-single-node-kv.json
@@ -12,10 +12,6 @@
         "ParameterValue": "5"
     },
     {
-        "ParameterKey": "K8sNodeCapacity",
-        "ParameterValue": "1"
-    },
-    {
         "ParameterKey": "InstanceType",
         "ParameterValue": "m4.large"
     },

--- a/ci/new-vpc-inputs-single-node-pre-release.json
+++ b/ci/new-vpc-inputs-single-node-pre-release.json
@@ -12,14 +12,6 @@
         "ParameterValue": "5"
     },
     {
-        "ParameterKey": "K8sNodeCapacity",
-        "ParameterValue": "1"
-    },
-    {
-        "ParameterKey": "InstanceType",
-        "ParameterValue": "m4.large"
-    },
-    {
         "ParameterKey": "Version",
         "ParameterValue": "Pre-release"
     },

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -124,7 +124,7 @@ Parameters:
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
 
   K8sNodeCapacity:
-    Default: '3'
+    Default: '1'
     Description: Initial number of CockroachDB nodes.
     Type: Number
     AllowedValues:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -307,7 +307,7 @@ Mappings:
 
   VersionTagMap:
     'Stable':
-      'image': 'cockroachdb/cockroach:latest'
+      'image': 'cockroachdb/cockroach:v1.1.5'
     'Pre-release':
       'image': 'cockroachdb/cockroach-unstable:latest'
 

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -189,7 +189,7 @@ Parameters:
   # Default 3. Choose initial nodes to run cluster workloads (in addition to the master node instance)
   # You can scale up your cluster later and add more nodes
   K8sNodeCapacity:
-    Default: '3'
+    Default: '1'
     Description: Initial number of CockroachDB nodes.
     Type: Number
     AllowedValues:


### PR DESCRIPTION
Using `cockroachdb/cockroach:latest` broke the template when a new 1.0.x release was pushed to docker hub; the template assumed we would always get a release higher than 1.1.0. This fix hard codes the latest 1.1.x to prevent this from happening again.

Additionally, this sets the default cluster size to be a single t2.medium node to bring down the average cost of running CockroachDB. Multinode clusters should use M- nodes at the minimum.

Fixes #12 