### PR TITLE
Switch livenessProbe back to using the /health endpoint

### DIFF
--- a/scripts/cockroachdb-statefulset.yaml
+++ b/scripts/cockroachdb-statefulset.yaml
@@ -96,7 +96,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /health?ready=1
+            path: /health
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 5


### PR DESCRIPTION
Otherwise if you don't run `cockroach init` quickly enough all the pods
will start to be repeatedly killed by the liveness checker. It's also a
more accurate reflection of the intended semantics of liveness (as
opposed to readiness).

Follow-up to https://github.com/cockroachdb/cockroachdb-cloudformation/pull/17