### PR TITLE
Remove (incorrectly) hard coded config path

### DIFF
--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -35,6 +35,7 @@ test -n "{{CockroachNodeCount}}"
 test -n "{{CockroachVolumeSize}}"
 test -n "{{CockroachDockerVersionTag}}"
 test -n "{{NodePortConfigUrl}}"
+test -n "{{StatefulSetConfigUrl}}"
 test -n "{{RegionLatitude}}"
 test -n "{{RegionLongitude}}"
 test -n "{{Workload}}"
@@ -123,12 +124,12 @@ ATTRS="instance-type={{InstanceType}}"
 
 # update default cockroachdb statefulset config to use desired settings
 /tmp/update-crdb-statefulset.py \
-    https://cockroach-cloudformation.s3.amazonaws.com/kubernetes/scripts/cockroachdb-statefulset.yaml \
+    {{StatefulSetConfigUrl}} \
     --size {{CockroachVolumeSize}} --version-tag {{CockroachDockerVersionTag}} --locality $LOCALITY \
     --attrs=$ATTRS --replicas={{CockroachNodeCount}} > /tmp/cockroachdb-statefulset.yaml
 
 kubectl apply -f /tmp/cockroachdb-statefulset.yaml
-kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cluster-init.yaml
+kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/v2.0.0/cloud/kubernetes/cluster-init.yaml
 kubectl apply -f {{NodePortConfigUrl}}
 
 

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -450,6 +450,7 @@ Resources:
                 DashboardUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/dashboard.yaml"
                 StorageClassUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/default.storageclass.yaml"
                 NodePortConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-nodeport-config.yaml"
+                StatefulSetConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-statefulset.yaml"
                 Region: !Ref AWS::Region
                 AvailabilityZone: !Ref AvailabilityZone
                 RegionLatitude:


### PR DESCRIPTION
The stateful set config was hard coded to a legacy s3 bucket. Also pointed the init path to a stable file rather than master. Fixes #16.