### PR TITLE
Add TPC-C 10 + other workload improvements

### DIFF
--- a/ci/config.yml
+++ b/ci/config.yml
@@ -20,6 +20,11 @@ tests:
       - eu-west-1
     parameter_input: new-vpc-inputs-single-node-ycsb.json
     template_file: kubernetes-cluster-with-new-vpc.template
+  single-node-vpc-tpcc10:
+    regions:
+      - eu-west-1
+    parameter_input: new-vpc-inputs-single-node-tpcc10.json
+    template_file: kubernetes-cluster-with-new-vpc.template
   multi-node-vpc-alpha:
     parameter_input: new-vpc-inputs-multi-node-pre-release.json
     template_file: kubernetes-cluster-with-new-vpc.template

--- a/ci/new-vpc-inputs-single-node-kv.json
+++ b/ci/new-vpc-inputs-single-node-kv.json
@@ -12,10 +12,6 @@
         "ParameterValue": "5"
     },
     {
-        "ParameterKey": "InstanceType",
-        "ParameterValue": "t2.medium"
-    },
-    {
         "ParameterKey": "Workload",
         "ParameterValue": "Evenly Distributed (KV)"
     },

--- a/ci/new-vpc-inputs-single-node-tpcc10.json
+++ b/ci/new-vpc-inputs-single-node-tpcc10.json
@@ -13,7 +13,7 @@
     },
     {
         "ParameterKey": "Workload",
-        "ParameterValue": "OLTP (TPC-C 100)"
+        "ParameterValue": "OLTP (TPC-C 10)"
     },
     {
         "ParameterKey": "Version",

--- a/ci/new-vpc-inputs-single-node-tpcc10.json
+++ b/ci/new-vpc-inputs-single-node-tpcc10.json
@@ -12,20 +12,12 @@
         "ParameterValue": "5"
     },
     {
-        "ParameterKey": "K8sNodeCapacity",
-        "ParameterValue": "3"
-    },
-    {
-        "ParameterKey": "InitialCockroachClusterSize",
-        "ParameterValue": "3"
-    },
-    {
-        "ParameterKey": "InstanceType",
-        "ParameterValue": "t2.medium"
+        "ParameterKey": "Workload",
+        "ParameterValue": "OLTP (TPC-C 100)"
     },
     {
         "ParameterKey": "Version",
-        "ParameterValue": "Pre-release"
+        "ParameterValue": "Stable"
     },
     {
         "ParameterKey": "QSS3BucketName",

--- a/ci/new-vpc-inputs-single-node-ycsb.json
+++ b/ci/new-vpc-inputs-single-node-ycsb.json
@@ -12,10 +12,6 @@
         "ParameterValue": "5"
     },
     {
-        "ParameterKey": "InstanceType",
-        "ParameterValue": "m4.large"
-    },
-    {
         "ParameterKey": "Workload",
         "ParameterValue": "Internet-style (YCSB)"
     },

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -39,6 +39,9 @@ test -n "{{StatefulSetConfigUrl}}"
 test -n "{{RegionLatitude}}"
 test -n "{{RegionLongitude}}"
 test -n "{{Workload}}"
+test -n "{{KVWorkloadConfigUrl}}"
+test -n "{{YCSBWorkloadConfigUrl}}"
+test -n "{{TPCC100WorkloadConfigUrl}}"
 
 # kubeadm wants lowercase for DNS (as it probably should)
 LB_DNS=$(echo "{{LoadBalancerDns}}" | tr 'A-Z' 'a-z')
@@ -152,10 +155,11 @@ CONCURRENCY=$(({{CockroachNodeCount}} * 100))
 
 if [[ "{{Workload}}"  =~ KV ]]
 then
-    kubectl run kv --image=cockroachdb/loadgen-kv --labels app=cockroachdb -- \
-    -drop=false -concurrency $CONCURRENCY -read-percent 95 -splits $NUMSPLITS -tolerate-errors "postgresql://root@cockroachdb-public:26257?application_name=kv&sslmode=disable"
+    kubectl create -f {{KVWorkloadConfigUrl}}
 elif [[ "{{Workload}}"  =~ YCSB ]]
 then
-    kubectl run ycsb --image=cockroachdb/loadgen-ycsb --labels app=cockroachdb -- \
-    -drop=false -concurrency $CONCURRENCY -splits $NUMSPLITS -tolerate-errors "postgresql://root@cockroachdb-public:26257?application_name=ycsb&sslmode=disable"
+    kubectl create -f {{YCSBWorkloadConfigUrl}}
+elif [[ "{{Workload}}"  =~ "TPC-C 10" ]]
+then
+    kubectl create -f {{TPCC100WorkloadConfigUrl}}
 fi

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -161,5 +161,5 @@ then
     kubectl create -f {{YCSBWorkloadConfigUrl}}
 elif [[ "{{Workload}}"  =~ "TPC-C 10" ]]
 then
-    kubectl create -f {{TPCC100WorkloadConfigUrl}}
+    kubectl create -f {{TPCC10WorkloadConfigUrl}}
 fi

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -41,7 +41,7 @@ test -n "{{RegionLongitude}}"
 test -n "{{Workload}}"
 test -n "{{KVWorkloadConfigUrl}}"
 test -n "{{YCSBWorkloadConfigUrl}}"
-test -n "{{TPCC100WorkloadConfigUrl}}"
+test -n "{{TPCC10WorkloadConfigUrl}}"
 
 # kubeadm wants lowercase for DNS (as it probably should)
 LB_DNS=$(echo "{{LoadBalancerDns}}" | tr 'A-Z' 'a-z')

--- a/scripts/workload-kv.yaml
+++ b/scripts/workload-kv.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kv
+spec:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - cockroachdb
+          topologyKey: kubernetes.io/hostname
+  containers:
+  - name: kv
+    image: cockroachdb/loadgen-kv
+    args: ["-concurrency=256", "-splits=1000", "-read-percent=95", "-tolerate-errors", "postgresql://root@cockroachdb-public:26257?application_name=kv&sslmode=disable"]
+

--- a/scripts/workload-tpcc-10.yaml
+++ b/scripts/workload-tpcc-10.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: tpcc-100
+  name: tpcc-10
 spec:
   affinity:
     podAntiAffinity:
@@ -16,11 +16,9 @@ spec:
               - cockroachdb
           topologyKey: kubernetes.io/hostname
   containers:
-  - name: tpcc-100
+  - name: tpcc-10
     image: cockroachdb/cockroach-unstable
     command:
           - "/bin/bash"
           - "-ecx"
-          # The use of qualified `hostname -f` is crucial:
-          # Other nodes aren't able to look up the unqualified hostname.
-          - "exec /cockroach/cockroach workload run tpcc --drop --warehouses 100 \"postgresql://root@cockroachdb-public:26257?application_name=tpcc&sslmode=disable\""
+          - "exec /cockroach/cockroach workload run tpcc --drop --warehouses 10 \"postgresql://root@cockroachdb-public:26257?application_name=tpcc&sslmode=disable\""

--- a/scripts/workload-tpcc.yaml
+++ b/scripts/workload-tpcc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tpcc-100
+spec:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - cockroachdb
+          topologyKey: kubernetes.io/hostname
+  containers:
+  - name: tpcc-100
+    image: cockroachdb/cockroach-unstable
+    command:
+          - "/bin/bash"
+          - "-ecx"
+          # The use of qualified `hostname -f` is crucial:
+          # Other nodes aren't able to look up the unqualified hostname.
+          - "exec /cockroach/cockroach workload run tpcc --drop --warehouses 100 \"postgresql://root@cockroachdb-public:26257?application_name=tpcc&sslmode=disable\""

--- a/scripts/workload-ycsb.yaml
+++ b/scripts/workload-ycsb.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ycsb
+spec:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - cockroachdb
+          topologyKey: kubernetes.io/hostname
+  containers:
+  - name: ycsb
+    image: cockroachdb/loadgen-ycsb
+    args: ["-concurrency=256", "-splits=1000", "-tolerate-errors", "postgresql://root@cockroachdb-public:26257?application_name=ycsb&sslmode=disable"]
+

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -155,6 +155,7 @@ Parameters:
     - None
     - Evenly Distributed (KV)
     - Internet-style (YCSB)
+    - OLTP (TPC-C 10)
 
 
 

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -221,6 +221,7 @@ Parameters:
     - None
     - Evenly Distributed (KV)
     - Internet-style (YCSB)
+    - OLTP (TPC-C 10)
 
 
   # S3 Bucket configuration: allows users to use their own downstream snapshots
@@ -477,6 +478,9 @@ Resources:
                 StorageClassUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/default.storageclass.yaml"
                 NodePortConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-nodeport-config.yaml"
                 StatefulSetConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/cockroachdb-statefulset.yaml"
+                KVWorkloadConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/workload-kv.yaml"
+                YCSBWorkloadConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/workload-ycsb.yaml"
+                TPCC10WorkloadConfigUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/workload-tpcc-10.yaml"
                 Region: !Ref AWS::Region
                 AvailabilityZone: !Ref AvailabilityZone
                 RegionLatitude:


### PR DESCRIPTION
This update adds TPC-C 10 and ensures the workload generators have an affinity for running on nodes that do not contain CockroachDB servers.

This gives us a pattern for adding arbitrary workloads to the cockroachdb cloudformation template

cc @robert-s-lee @rkruze @danhhz 

Closes #26 